### PR TITLE
breaking: Use GOV.UK font sizes instead of custom font sizes

### DIFF
--- a/demo/assets/src/scss/main.scss
+++ b/demo/assets/src/scss/main.scss
@@ -14,7 +14,6 @@ $govuk-root-font-size: 19px;
 @import '../../../../hmlr_design_system/components/back-link/style';
 @import '../../../../hmlr_design_system/components/button/style';
 @import '../../../../hmlr_design_system/components/links/style';
-@import '../../../../hmlr_design_system/components/text-input/style';
 @import '../../../../hmlr_design_system/components/typography/style';
 @import '../../../../hmlr_design_system/components/footer/style';
 @import '../../../../hmlr_design_system/components/cookie-banner/style';

--- a/demo/assets/src/scss/main.scss
+++ b/demo/assets/src/scss/main.scss
@@ -1,13 +1,14 @@
-// GOV.UK design system
+// GOV.UK Design System
 $govuk-images-path: '/ui/.govuk-frontend/images/';
 $govuk-fonts-path: '/ui/.govuk-frontend/fonts/';
 $govuk-font-family: "Arial", sans-serif;
+$govuk-root-font-size: 19px;
 
+@import 'govuk-frontend/govuk/all';
+
+// HMLR Design System
 @import '../../../../hmlr_design_system/settings/variables';
 
-@import 'govuk-frontend/govuk/all';  // Feel free to be more selective than this
-
-// Design system components
 @import '../../../../hmlr_design_system/components/layout/style';
 @import '../../../../hmlr_design_system/components/header/style';
 @import '../../../../hmlr_design_system/components/back-link/style';
@@ -17,7 +18,6 @@ $govuk-font-family: "Arial", sans-serif;
 @import '../../../../hmlr_design_system/components/typography/style';
 @import '../../../../hmlr_design_system/components/footer/style';
 @import '../../../../hmlr_design_system/components/cookie-banner/style';
-
 
 // App specific code
 @import 'partials/code-blocks';

--- a/demo/templates/layout.html
+++ b/demo/templates/layout.html
@@ -47,7 +47,8 @@
     {% if backurl %}
       {{ govukBackLink({
         "text": "Back",
-          "href": backurl
+        "href": backurl,
+        "classes": "govuk-!-margin-bottom-6"
         }) }}
     {% endif %}
   {% endblock %}

--- a/demo/templates/wide-layout.html
+++ b/demo/templates/wide-layout.html
@@ -33,7 +33,8 @@
           {% if backurl %}
             {{ govukBackLink({
               "text": "Back",
-                "href": backurl
+              "href": backurl,
+              "classes": "govuk-!-margin-bottom-6"
               }) }}
           {% endif %}
         {% endblock %}

--- a/hmlr_design_system/components/back-link/style.scss
+++ b/hmlr_design_system/components/back-link/style.scss
@@ -2,8 +2,6 @@
 
 .hmlr-theme {
   .govuk-back-link {
-    font-size: $font-size--meta;
-
     &:hover {
       color: $govuk-secondary-text-colour;
       border-color: $govuk-secondary-text-colour;

--- a/hmlr_design_system/components/button/style.scss
+++ b/hmlr_design_system/components/button/style.scss
@@ -3,11 +3,6 @@
   $alt-button--disabled: #709cc7;
   $alt-button--hover: #295184;
 
-  .govuk-button {
-    font-size: $font-size;
-    padding: 8px 20px;
-  }
-
   .hmlr-button--alt {
     background-color: $alt-button;
 

--- a/hmlr_design_system/components/header/style.scss
+++ b/hmlr_design_system/components/header/style.scss
@@ -40,7 +40,7 @@
   }
 
   .hmlr-header__title {
-    @extend %govuk-heading-l;
+    @include govuk-font($size: 24, $weight: bold, $line-height: 1);
     color: $govuk-text-colour;
     margin-bottom: 0;
     display: inline-block;

--- a/hmlr_design_system/components/header/style.scss
+++ b/hmlr_design_system/components/header/style.scss
@@ -41,8 +41,7 @@
 
   .hmlr-header__title {
     @extend %govuk-heading-l;
-    font-size: 20px;
-    color: govuk-colour("black");
+    color: $govuk-text-colour;
     margin-bottom: 0;
     display: inline-block;
     vertical-align: middle;

--- a/hmlr_design_system/components/text-input/demos/demo.html
+++ b/hmlr_design_system/components/text-input/demos/demo.html
@@ -23,8 +23,7 @@
       "text": "Label"
     },
     "errorMessage": {
-      "text": "This field is required",
-      "classes": "'govuk-error-message govuk-!-width-three-quarters"
+      "text": "This field is required"
     },
     "id": "label",
     "classes": "govuk-!-width-three-quarters",

--- a/hmlr_design_system/components/text-input/style.scss
+++ b/hmlr_design_system/components/text-input/style.scss
@@ -1,9 +1,0 @@
-@import '../../settings/variables';
-
-.hmlr-theme {
-  .govuk-input {
-    height: 26px;
-    padding: 14px 3px;
-    line-height: 20px;
-  }
-}

--- a/hmlr_design_system/components/text-input/style.scss
+++ b/hmlr_design_system/components/text-input/style.scss
@@ -2,7 +2,6 @@
 
 .hmlr-theme {
   .govuk-input {
-    font-size: $font-size;
     height: 26px;
     padding: 14px 3px;
     line-height: 20px;

--- a/hmlr_design_system/components/typography/style.scss
+++ b/hmlr_design_system/components/typography/style.scss
@@ -2,32 +2,15 @@
 
 .hmlr-theme {
   .govuk-heading-xl {
-    font-size: 32px;
     margin: 32px 0;
   }
 
   .govuk-heading-l {
-    font-size: 24px;
     margin-bottom: 24px;
 
     @include govuk-media-query($from: desktop) {
-      font-size: 28px;
       margin-bottom: 28px;
     }
-  }
-
-  .govuk-heading-m{
-    font-size: 24px;
-    margin-bottom: 24px;
-  }
-
-  .govuk-heading-s {
-    font-size: 19px;
-    margin-bottom: 19px;
-  }
-
-  .govuk-fieldset__heading {
-    font-size: 28px;
   }
 
   .hmlr-meta {
@@ -39,24 +22,5 @@
     list-style-position: inside;
     margin: 0;
     padding: 0;
-  }
-
-  .govuk-fieldset__heading {
-    font-size: 28px;
-  }
-
-  .govuk-fieldset__legend--l {
-    font-size: 28px;
-    font-weight: 600;
-  }
-
-  .govuk-fieldset__legend--m {
-    font-size: 24px;
-    font-weight: 600;
-  }
-
-  .govuk-fieldset__legend--s {
-    font-size: 19px;
-    font-weight: 600;
   }
 }

--- a/hmlr_design_system/components/typography/style.scss
+++ b/hmlr_design_system/components/typography/style.scss
@@ -26,25 +26,16 @@
     margin-bottom: 19px;
   }
 
-  .govuk-body {
-    font-size: $font-size;
-  }
-
   .govuk-fieldset__heading {
     font-size: 28px;
   }
 
-  .govuk-hint {
-    font-size: $font-size;
-  }
-
   .hmlr-meta {
-    font-size: $font-size--meta;
+    @include govuk-font($size: 16);
     color: $govuk-secondary-text-colour;
   }
 
   .govuk-list {
-    font-size: $font-size;
     list-style-position: inside;
     margin: 0;
     padding: 0;
@@ -67,13 +58,5 @@
   .govuk-fieldset__legend--s {
     font-size: 19px;
     font-weight: 600;
-  }
-
-  .govuk-label {
-    font-size: $font-size;
-  }
-
-  .govuk-error-message {
-    font-size: $font-size;
   }
 }

--- a/hmlr_design_system/components/typography/style.scss
+++ b/hmlr_design_system/components/typography/style.scss
@@ -1,18 +1,6 @@
 @import '../../settings/variables';
 
 .hmlr-theme {
-  .govuk-heading-xl {
-    margin: 32px 0;
-  }
-
-  .govuk-heading-l {
-    margin-bottom: 24px;
-
-    @include govuk-media-query($from: desktop) {
-      margin-bottom: 28px;
-    }
-  }
-
   .hmlr-meta {
     @include govuk-font($size: 16);
     color: $govuk-secondary-text-colour;

--- a/hmlr_design_system/settings/variables.scss
+++ b/hmlr_design_system/settings/variables.scss
@@ -5,6 +5,3 @@ $hmlr-green-3: #87c426;
 $hmlr-grid-padding: 40px;
 $hmlr-grid-column-width: 300px;
 $hmlr-grid-start-breakpoint: 3.33 * $hmlr-grid-column-width;
-
-$font-size: 16px;
-$font-size--meta: 14px;


### PR DESCRIPTION
# Why?

It's possible to set a base font size with the GOV.UK Design System by setting the variable `$govuk-root-font-size`. This applies automatically to all GOV.UK components so we don't have to manually change the font size. This is also more future proof as new components in the future will automatically use this font size.

It'd be great if the HMLR Design System could adopt this approach for consistency and accessibility.

# What does this break?

Since this removes the custom font size set for each component, services that use HMLR Design System will have to set `$govuk-root-font-size` themselves if they want to use a smaller/larger font size than default.